### PR TITLE
feat: add Queue implementation using custom singly linked list

### DIFF
--- a/DataStructures/Queue.java
+++ b/DataStructures/Queue.java
@@ -1,0 +1,63 @@
+public class Queue<T> {
+    // Node class for custom singly linked list
+    private static class Node<T> {
+        T data;
+        Node<T> next;
+
+        Node(T data) {
+            this.data = data;
+            this.next = null;
+        }
+    }
+
+    private Node<T> front;  
+    private Node<T> rear;   
+    private int size;       
+
+    public Queue() {
+        this.front = null;
+        this.rear = null;
+        this.size = 0;
+    }
+
+    public void enqueue(T data) {
+        Node<T> newNode = new Node<>(data);
+        if (rear == null) front = rear = newNode;
+        
+        else
+        {
+            rear.next = newNode;
+            rear = newNode;
+        }
+        size++;
+    }
+
+    public T dequeue() {
+        if (isEmpty()) {
+            throw new IllegalStateException("Queue is empty. Cannot dequeue.");
+        }
+        T value = front.data;
+        front = front.next;
+        if (front == null) rear = null;
+        
+        size--;
+        return value;
+    }
+
+
+    public T peek() {
+        if (isEmpty()) {
+            throw new IllegalStateException("Queue is empty. Cannot peek.");
+        }
+        return front.data;
+    }
+
+    public boolean isEmpty() {
+        return front == null;
+    }
+
+    // Get current size of the queue
+    public int size() {
+        return size;
+    }
+}

--- a/DataStructures/Queue.java
+++ b/DataStructures/Queue.java
@@ -1,3 +1,16 @@
+/**
+ * Program Title: Queue (Linked List Implementation)
+ * Author: [Ahad-23]
+ * Date: 2025-10-08
+ *
+ * Description: Implements a generic Queue data structure using a custom
+ * Singly Linked List. Operations (enqueue, dequeue, peek) are designed
+ * to adhere to the FIFO (First-In, First-Out) principle.
+ *
+ * Time Complexity: O(1) for all main operations (enqueue, dequeue, peek).
+ * Space Complexity: O(N) where N is the number of elements stored.
+ */
+
 public class Queue<T> {
     // Node class for custom singly linked list
     private static class Node<T> {


### PR DESCRIPTION
This PR adds a Queue class implementation in the DataStructures folder.
-Implemented using a custom singly linked list (no built-in LinkedList used).
-Core methods: enqueue(), dequeue(), and peek().
-Both enqueue and dequeue operate in O(1) time complexity.
-Follows 4-space indentation and K&R brace style as required.
-Tested with sample inputs and verified functionality.